### PR TITLE
Enable sphinx viewcode plugin for source code links.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,9 +43,9 @@ author = "Andrew Yoon"
 # ones.
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.graphviz",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.graphviz",
     "sphinx.ext.viewcode",
 ]
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.graphviz",
+    "sphinx.ext.viewcode",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Hi, this enables source code links in the API reference documentation.

What do you think of enabling this?