### PR TITLE
Fix pen width padding in bounding/clipping rects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.7 (unreleased)
+- Fix [clipping of thick pens](https://github.com/DigiScore/neoscore/issues/14) thanks to help from @Xavman42.
+
 # 0.1.6 (2022-07-27)
 - Fix bug affecting path resolution in image export on Windows with Python 3.7
 

--- a/neoscore/interface/path_interface.py
+++ b/neoscore/interface/path_interface.py
@@ -122,10 +122,11 @@ class PathInterface(PositionedObjectInterface):
             1,
             self.rotation,
             self.background_brush.qt_object if self.background_brush else None,
+            defer_geometry_calculation=True,
         )
         qt_object.setPos(point_to_qt_point_f(self.pos))
         qt_object.setBrush(self.brush.qt_object)
-        qt_object.setPen(self.pen.qt_object)  # No pen
+        qt_object.setPen(self.pen.qt_object)
         if self.z_index != 0:
             qt_object.setZValue(self.z_index)
         qt_object.update_geometry()

--- a/neoscore/interface/text_interface.py
+++ b/neoscore/interface/text_interface.py
@@ -90,6 +90,7 @@ class TextInterface(PositionedObjectInterface):
         qt_object.setPen(self.pen.qt_object)
         if self.z_index != 0:
             qt_object.setZValue(self.z_index)
+        qt_object.update_geometry()
         return qt_object
 
     def _get_path(self, text: str, font: FontInterface, scale: float) -> QClippingPath:
@@ -111,6 +112,7 @@ class TextInterface(PositionedObjectInterface):
             scale,
             self.rotation,
             self.background_brush.qt_object if self.background_brush else None,
+            defer_geometry_calculation=True,
         )
 
     @staticmethod

--- a/tests/test_interface/test_qt/test_q_clipping_path.py
+++ b/tests/test_interface/test_qt/test_q_clipping_path.py
@@ -8,7 +8,8 @@ from ...helpers import AppTest
 class TestQClippingPath(AppTest):
     def setUp(self):
         super().setUp()
-        self.pen = QPen(QColor("#000000"), 1)
+        self.pen = QPen(QColor("#000000"), 2)
+        self.pen_padding_width = self.pen.widthF() / 2
 
     def test_clip_measurements_scale_adjusted(self):
         painter_path = QPainterPath()
@@ -22,12 +23,17 @@ class TestQClippingPath(AppTest):
         painter_path.lineTo(100, 200)
         obj = QClippingPath(painter_path, 0, None)
         obj.setPen(self.pen)
+        obj.update_geometry()
         # bounding rect should match that of the path plus padding for the pen width
         raw_path_rect = painter_path.boundingRect()
-        assert obj.boundingRect().x() == raw_path_rect.x() - 1
-        assert obj.boundingRect().y() == raw_path_rect.y() - 1
-        assert obj.boundingRect().width() == raw_path_rect.width() + 5 + 2
-        assert obj.boundingRect().height() == raw_path_rect.height() + 2
+        assert obj.boundingRect().x() == raw_path_rect.x() - self.pen_padding_width
+        assert obj.boundingRect().y() == raw_path_rect.y() - self.pen_padding_width
+        assert obj.boundingRect().width() == raw_path_rect.width() + 5 + (
+            self.pen_padding_width * 2
+        )
+        assert obj.boundingRect().height() == raw_path_rect.height() + (
+            self.pen_padding_width * 2
+        )
         assert obj.clip_rect == obj.boundingRect()
 
     def test_geometry_covering_end_of_path(self):
@@ -36,11 +42,17 @@ class TestQClippingPath(AppTest):
         painter_path.lineTo(100, 200)
         obj = QClippingPath(painter_path, 50, None)
         obj.setPen(self.pen)
+        obj.update_geometry()
         raw_path_rect = painter_path.boundingRect()
         assert obj.boundingRect().x() == raw_path_rect.x()
-        assert obj.boundingRect().y() == raw_path_rect.y() - 1
-        assert obj.boundingRect().width() == raw_path_rect.width() + 5 - 50 + 1
-        assert obj.boundingRect().height() == raw_path_rect.height() + 2
+        assert obj.boundingRect().y() == raw_path_rect.y() - self.pen_padding_width
+        assert (
+            obj.boundingRect().width()
+            == raw_path_rect.width() + 5 - 50 + self.pen_padding_width
+        )
+        assert obj.boundingRect().height() == raw_path_rect.height() + (
+            self.pen_padding_width * 2
+        )
         assert obj.clip_rect == obj.boundingRect().translated(50, 0)
 
     def test_geometry_covering_start_of_path(self):
@@ -49,11 +61,14 @@ class TestQClippingPath(AppTest):
         painter_path.lineTo(100, 200)
         obj = QClippingPath(painter_path, 0, 50)
         obj.setPen(self.pen)
+        obj.update_geometry()
         raw_path_rect = painter_path.boundingRect()
-        assert obj.boundingRect().x() == raw_path_rect.x() - 1
-        assert obj.boundingRect().y() == raw_path_rect.y() - 1
-        assert obj.boundingRect().width() == 50 + 5 + 1
-        assert obj.boundingRect().height() == raw_path_rect.height() + 2
+        assert obj.boundingRect().x() == raw_path_rect.x() - self.pen_padding_width
+        assert obj.boundingRect().y() == raw_path_rect.y() - self.pen_padding_width
+        assert obj.boundingRect().width() == 50 + 5 + self.pen_padding_width
+        assert obj.boundingRect().height() == raw_path_rect.height() + (
+            self.pen_padding_width * 2
+        )
         assert obj.clip_rect == obj.boundingRect()
 
     def test_geometry_covering_middle_of_path(self):
@@ -62,9 +77,12 @@ class TestQClippingPath(AppTest):
         painter_path.lineTo(100, 200)
         obj = QClippingPath(painter_path, 25, 30)
         obj.setPen(self.pen)
+        obj.update_geometry()
         raw_path_rect = painter_path.boundingRect()
         assert obj.boundingRect().x() == raw_path_rect.x()
-        assert obj.boundingRect().y() == raw_path_rect.y() - 1
+        assert obj.boundingRect().y() == raw_path_rect.y() - self.pen_padding_width
         assert obj.boundingRect().width() == 30 + 5
-        assert obj.boundingRect().height() == raw_path_rect.height() + 2
+        assert obj.boundingRect().height() == raw_path_rect.height() + (
+            self.pen_padding_width * 2
+        )
         assert obj.clip_rect == obj.boundingRect().translated(25, 0)


### PR DESCRIPTION
The key problem was that the QClippingPath's padding was set from the
pen value before the pen was set, so it was always using the default
pen width even when the drawn path had a different pen. The solution
was to simply defer the padding calculation to occur within
`update_geometry()`.

This change also fixes a few other related issues:

- The padding derived from pen width is now `width / 2`, not just the
  width, since Qt divides the pen stroke width evenly across the ideal
  path line.
- Text paths were also failing to update their clipping geometry after
  setting the pen.
- Paths were unnecessarily calling `update_geometry` twice for every
  render. This change adds a QClippingPath init parameter
  `defer_geometry_calculation` which allows us to improve performance
  by avoiding this.

Fixes #14 thanks to help from @Xavman42