### PR TITLE
PedalLine half-lfit bug fixed

### DIFF
--- a/neoscore/western/pedal_line.py
+++ b/neoscore/western/pedal_line.py
@@ -82,22 +82,25 @@ class PedalLine(Spanner, MusicPath):
         self.line_to(self.music_font.unit(0), descent)
 
         # Draw half lift positions, if any exist
-        for pos in self.half_lift_positions:
-            if isinstance(pos, tuple):
-                lift_parent = pos[1]
-                lift_center_x = pos[0]
-                lift_center_y = lift_parent.map_to(self).y + descent
-            elif isinstance(pos, Unit):
-                lift_parent = self
-                lift_center_x = pos
-                lift_center_y = descent
-            else:
-                raise AttributeError("Invalid half lift position: {}".format(pos))
-            lift_left_x = lift_center_x - half_lift_x_extent
-            lift_right_x = lift_center_x + half_lift_x_extent
-            self.line_to(lift_left_x, lift_center_y, lift_parent)
-            self.line_to(lift_center_x, lift_center_y - descent, lift_parent)
-            self.line_to(lift_right_x, lift_center_y, lift_parent)
+        if self.half_lift_positions:
+            for pos in self.half_lift_positions:
+                if pos >= self.end_x - (half_lift_x_extent * 2):
+                    raise AttributeError("Invalid half lift position: {}".format(pos))
+                if isinstance(pos, tuple):
+                    lift_parent = pos[1]
+                    lift_center_x = pos[0]
+                    lift_center_y = lift_parent.map_to(self).y + descent
+                elif isinstance(pos, Unit):
+                    lift_parent = self
+                    lift_center_x = pos
+                    lift_center_y = descent
+                else:
+                    raise AttributeError("Invalid half lift position: {}".format(pos))
+                lift_left_x = lift_center_x - half_lift_x_extent
+                lift_right_x = lift_center_x + half_lift_x_extent
+                self.line_to(lift_left_x, lift_center_y, lift_parent)
+                self.line_to(lift_center_x, lift_center_y - descent, lift_parent)
+                self.line_to(lift_right_x, lift_center_y, lift_parent)
 
         # Draw closing crook
         self.line_to(self.end_x, self.end_y + descent, self.end_parent)

--- a/tests/test_western/test_pedal_line.py
+++ b/tests/test_western/test_pedal_line.py
@@ -1,0 +1,39 @@
+from ..helpers import AppTest
+import pytest
+
+from neoscore.western.staff import Staff
+from neoscore.western.pedal_line import PedalLine
+from neoscore.core.units import ZERO, Mm
+from neoscore.core.point import Point
+
+class TestBarLine(AppTest):
+    def setUp(self):
+        super().setUp()
+        self.staff = Staff((Mm(0), Mm(0)), None, Mm(100))
+
+    def test_full_pedal_line(self):
+        pedal_line = PedalLine((Mm(0), Mm(0)),
+                               self.staff,
+                               Mm(100))
+        assert pedal_line.pos == Point(x=Mm(0.0), y=Mm(0.0))
+        assert pedal_line.end_pos == Point(x=Mm(100.0), y=Mm(0.0))
+        assert pedal_line.elements[0].pos == Point(x=Mm(0.0), y=Mm(0.0))
+        assert pedal_line.elements[3].pos == Point(x=Mm(100.0), y=Mm(0.0))
+
+    def test_pedal_line_half_lift(self):
+        pedal_line = PedalLine((Mm(0), Mm(0)),
+                               self.staff,
+                               Mm(100),
+                               half_lift_positions=[Mm(10), Mm(50), Mm(95)]
+                               )
+        assert pedal_line.elements[3].pos == Point(x=Mm(10.0), y=Mm(0.0))
+        assert pedal_line.elements[6].pos == Point(x=Mm(50.0), y=Mm(0.0))
+        assert pedal_line.elements[9].pos == Point(x=Mm(95.0), y=Mm(0.0))
+
+    def test_pedal_line_half_lift_too_long(self):
+        with pytest.raises(AttributeError):
+            PedalLine((Mm(0), Mm(0)),
+                      self.staff,
+                      Mm(100),
+                      half_lift_positions=[Mm(10), Mm(50), Mm(120)]
+                      )

--- a/tests/test_western/test_pedal_line.py
+++ b/tests/test_western/test_pedal_line.py
@@ -3,16 +3,16 @@ import pytest
 
 from neoscore.western.staff import Staff
 from neoscore.western.pedal_line import PedalLine
-from neoscore.core.units import ZERO, Mm
-from neoscore.core.point import Point
+from neoscore.core.units import Mm
+from neoscore.core.point import Point, ORIGIN
 
-class TestBarLine(AppTest):
+class TestPedalLine(AppTest):
     def setUp(self):
         super().setUp()
-        self.staff = Staff((Mm(0), Mm(0)), None, Mm(100))
+        self.staff = Staff(ORIGIN, None, Mm(100))
 
     def test_full_pedal_line(self):
-        pedal_line = PedalLine((Mm(0), Mm(0)),
+        pedal_line = PedalLine(ORIGIN,
                                self.staff,
                                Mm(100))
         assert pedal_line.pos == Point(x=Mm(0.0), y=Mm(0.0))
@@ -21,7 +21,7 @@ class TestBarLine(AppTest):
         assert pedal_line.elements[3].pos == Point(x=Mm(100.0), y=Mm(0.0))
 
     def test_pedal_line_half_lift(self):
-        pedal_line = PedalLine((Mm(0), Mm(0)),
+        pedal_line = PedalLine(ORIGIN,
                                self.staff,
                                Mm(100),
                                half_lift_positions=[Mm(10), Mm(50), Mm(95)]
@@ -32,7 +32,7 @@ class TestBarLine(AppTest):
 
     def test_pedal_line_half_lift_too_long(self):
         with pytest.raises(AttributeError):
-            PedalLine((Mm(0), Mm(0)),
+            PedalLine(ORIGIN,
                       self.staff,
                       Mm(100),
                       half_lift_positions=[Mm(10), Mm(50), Mm(120)]

--- a/tests/test_western/test_pedal_line.py
+++ b/tests/test_western/test_pedal_line.py
@@ -1,10 +1,12 @@
-from ..helpers import AppTest
 import pytest
 
-from neoscore.western.staff import Staff
-from neoscore.western.pedal_line import PedalLine
+from neoscore.core.point import ORIGIN, Point
 from neoscore.core.units import Mm
-from neoscore.core.point import Point, ORIGIN
+from neoscore.western.pedal_line import PedalLine
+from neoscore.western.staff import Staff
+
+from ..helpers import AppTest
+
 
 class TestPedalLine(AppTest):
     def setUp(self):
@@ -12,28 +14,25 @@ class TestPedalLine(AppTest):
         self.staff = Staff(ORIGIN, None, Mm(100))
 
     def test_full_pedal_line(self):
-        pedal_line = PedalLine(ORIGIN,
-                               self.staff,
-                               Mm(100))
+        pedal_line = PedalLine(ORIGIN, self.staff, Mm(100))
         assert pedal_line.pos == Point(x=Mm(0.0), y=Mm(0.0))
         assert pedal_line.end_pos == Point(x=Mm(100.0), y=Mm(0.0))
         assert pedal_line.elements[0].pos == Point(x=Mm(0.0), y=Mm(0.0))
         assert pedal_line.elements[3].pos == Point(x=Mm(100.0), y=Mm(0.0))
 
     def test_pedal_line_half_lift(self):
-        pedal_line = PedalLine(ORIGIN,
-                               self.staff,
-                               Mm(100),
-                               half_lift_positions=[Mm(10), Mm(50), Mm(95)]
-                               )
+        pedal_line = PedalLine(
+            ORIGIN, self.staff, Mm(100), half_lift_positions=[Mm(10), Mm(50), Mm(95)]
+        )
         assert pedal_line.elements[3].pos == Point(x=Mm(10.0), y=Mm(0.0))
         assert pedal_line.elements[6].pos == Point(x=Mm(50.0), y=Mm(0.0))
         assert pedal_line.elements[9].pos == Point(x=Mm(95.0), y=Mm(0.0))
 
     def test_pedal_line_half_lift_too_long(self):
         with pytest.raises(AttributeError):
-            PedalLine(ORIGIN,
-                      self.staff,
-                      Mm(100),
-                      half_lift_positions=[Mm(10), Mm(50), Mm(120)]
-                      )
+            PedalLine(
+                ORIGIN,
+                self.staff,
+                Mm(100),
+                half_lift_positions=[Mm(10), Mm(50), Mm(120)],
+            )


### PR DESCRIPTION
Pedal Line currently crashes if NO half lift positions are declared. Added if statement to check if half_lift_positions is empty. And checks if half lift positions are within pedal line length. 