### PR TITLE
Make transform origin respect Text alignment

### DIFF
--- a/neoscore/core/text.py
+++ b/neoscore/core/text.py
@@ -171,8 +171,11 @@ class Text(PaintedObject):
         """The bounding rect for this text positioned relative to ``pos``.
 
         The rect ``(x, y)`` position is relative to the object's position.
+        Note that with text objects, the rect's ``(x, y)`` position will
+        typically not be at the origin.
 
-        Note that this currently accounts for scaling, but not rotation.
+        This currently accounts for scaling and alignment, but not rotation.
+        Rotated objects will generally have incorrect bounding rects.
         """
         raw_rect = self._raw_scaled_bounding_rect
         alignment_offset = self._alignment_offset

--- a/neoscore/core/text.py
+++ b/neoscore/core/text.py
@@ -206,7 +206,7 @@ class Text(PaintedObject):
             None if inside_flowable else self.parent.interface_for_children,
             self.scale,
             self.rotation,
-            self.transform_origin,
+            self.transform_origin - self._alignment_offset,
             self.brush.interface,
             self.pen.interface,
             self.text,

--- a/tests/test_core/test_text.py
+++ b/tests/test_core/test_text.py
@@ -151,12 +151,14 @@ class TestText(AppTest):
             "testing",
             alignment_x=AlignmentX.CENTER,
             alignment_y=AlignmentY.CENTER,
-            transform_origin=(Mm(15), Mm(10)),
+            transform_origin=(Unit(15), Unit(10)),
         )
         obj.render()
         rendered_pos = obj.interfaces[0].pos
         transform_origin = obj.interfaces[0].transform_origin
         assert_almost_equal(rendered_pos, Point(Unit(-20), Unit(2.5)), epsilon=1.5)
         assert_almost_equal(
-            transform_origin, Point(Unit(-20) - Mm(15), Unit(2.5) - Mm(10)), epsilon=1.5
+            transform_origin,
+            Point(Unit(35), Unit(7.5)),
+            epsilon=1.5,
         )

--- a/tests/test_core/test_text.py
+++ b/tests/test_core/test_text.py
@@ -151,7 +151,12 @@ class TestText(AppTest):
             "testing",
             alignment_x=AlignmentX.CENTER,
             alignment_y=AlignmentY.CENTER,
+            transform_origin=(Mm(15), Mm(10)),
         )
         obj.render()
         rendered_pos = obj.interfaces[0].pos
+        transform_origin = obj.interfaces[0].transform_origin
         assert_almost_equal(rendered_pos, Point(Unit(-20), Unit(2.5)), epsilon=1.5)
+        assert_almost_equal(
+            transform_origin, Point(Unit(-20) - Mm(15), Unit(2.5) - Mm(10)), epsilon=1.5
+        )


### PR DESCRIPTION
Helps address issue raised in #109