### PR TITLE
Jupyter Notebook integration to main branch

### DIFF
--- a/neoscore/core/neoscore.py
+++ b/neoscore/core/neoscore.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from time import time
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple
 from warnings import warn
+from IPython import get_ipython  # type: ignore
+from IPython.display import display, Image  # type: ignore
 
 import img2pdf  # type: ignore
 from typing_extensions import TypeAlias
@@ -459,6 +461,26 @@ def render_image(
         raise InvalidImageFormatError(
             "image_path {} is not in a supported format.".format(dest)
         )
+    
+    # checking jupyter notebook
+    try:
+        get_ipython()
+        in_jupyter = True
+    except NameError:
+        in_jupyter = False
+
+    if in_jupyter:
+        # Jupyter notebook detected
+        print("Running in a Jupyter environment")
+
+        # image rendering will go here
+
+        # display image from dest
+        display(Image(dest))
+
+        return
+    else:
+        print("Not running in a Jupyter environment")
 
     bg_color = background_brush.color
     _render_document(False, background_brush)

--- a/neoscore/core/neoscore.py
+++ b/neoscore/core/neoscore.py
@@ -274,6 +274,16 @@ def show(
     global _display_page_geometry_in_refresh_func
     _display_page_geometry_in_refresh_func = display_page_geometry
 
+    try:
+        get_ipython()
+        in_jupyter = True
+    except NameError:
+        in_jupyter = False
+
+    if in_jupyter:
+        # Jupyter notebook detected (for debugging purposes, will be removed in production)
+        print("Running in a Jupyter environment")
+
     _render_document(display_page_geometry, background_brush)
     if refresh_func:
         set_refresh_func(refresh_func)
@@ -470,17 +480,8 @@ def render_image(
         in_jupyter = False
 
     if in_jupyter:
-        # Jupyter notebook detected
+        # Jupyter notebook detected (for debugging purposes, will be removed in production)
         print("Running in a Jupyter environment")
-
-        # image rendering will go here
-
-        # display image from dest
-        display(Image(dest))
-
-        return
-    else:
-        print("Not running in a Jupyter environment")
 
     bg_color = background_brush.color
     _render_document(False, background_brush)
@@ -496,6 +497,10 @@ def render_image(
     )
     if wait:
         thread.join()
+
+        if in_jupyter:
+            display(Image(dest))
+
     return thread
 
 

--- a/neoscore/core/neoscore.py
+++ b/neoscore/core/neoscore.py
@@ -281,8 +281,7 @@ def show(
         in_jupyter = False
 
     if in_jupyter:
-        # Jupyter notebook detected (for debugging purposes, will be removed in production)
-        print("Running in a Jupyter environment")
+        raise RuntimeError("Unable to call the function show() in this context.")
 
     _render_document(display_page_geometry, background_brush)
     if refresh_func:


### PR DESCRIPTION
This is the code for the Jupyter notebook integration, using the render_image() function. A few things to note:

- The kernel crashes after a cell is rerun at least twice.
- Flowables that span more than an individual stave appear next to each other rather than underneath each other.

Below is some sample code that produces the flowable error (I believe any set of code eventually leads to the kernel crashing when run multiple times).

```
from neoscore.core import neoscore
from neoscore.core.point import ORIGIN
from neoscore.core.units import ZERO, Mm
from neoscore.western.chordrest import Chordrest
from neoscore.western.clef import Clef
from neoscore.western.notehead import Notehead
from neoscore.western.slur import Slur
from neoscore.western.staff import Staff
from neoscore.western.tie import Tie
from neoscore.core.document import Document
from neoscore.core.flowable import Flowable

neoscore.setup()

myflow = Flowable((ZERO, ZERO), None, Mm(1000), Mm(2000))

staff = Staff((Mm(10), Mm(10)), myflow, Mm(1500))
clef = Clef(ZERO, staff, "treble")

note1 = Chordrest(Mm(10), staff, ["c'"], (1, 4))
note2 = Chordrest(Mm(20), staff, ["f'"], (1, 4))
slur = Slur((Mm(0), Mm(0)), note1, (Mm(0), Mm(-5)), note2)

note3 = Chordrest(Mm(30), staff, ["d'"], (1, 4))
note4 = Chordrest(Mm(40), staff, ["d'"], (1, 4))
tie = Tie((Mm(0), Mm(0)), note3, Mm(10))

nh1 = Notehead(Mm(60), staff, "e", (1, 4))
nh2 = Notehead(Mm(80), staff, "b", (1, 4))
Tie(ORIGIN, nh1, ZERO, nh2)

neoscore.render_image(rect=None)
```